### PR TITLE
Fix issue #231

### DIFF
--- a/client-side-filtering/src/main/java/org/owasp/webgoat/plugin/ClientSideFiltering.java
+++ b/client-side-filtering/src/main/java/org/owasp/webgoat/plugin/ClientSideFiltering.java
@@ -156,7 +156,7 @@ public class ClientSideFiltering extends SequentialLessonAdapter
          * 1. If clientSideFiltering.jsp has an XPath filter to
          *    limit the data being returned.
          */
-        String file = LessonUtil.getLessonDirectory(s, this) + "jsp/clientSideFiltering.jsp";
+        String file = LessonUtil.getLessonDirectory(s, this) + "/jsp/clientSideFiltering.jsp";
         String content = getFileContent(file);
 
         if (content.indexOf("[Managers/Manager/text()") != -1)

--- a/command-injection/src/main/java/org/owasp/webgoat/plugin/CommandInjection.java
+++ b/command-injection/src/main/java/org/owasp/webgoat/plugin/CommandInjection.java
@@ -106,7 +106,7 @@ public class CommandInjection extends LessonAdapter {
                     }
                 }
             }
-            File safeDir = new File(LessonUtil.getLessonDirectory(s, this), "resources");
+            File safeDir = new File(LessonUtil.getLessonDirectory(s, this), "/resources");
             ec.addElement(new BR());
             ec.addElement(new BR());
             ec.addElement(new StringElement(getLabelManager().get("YouAreCurrentlyViewing") + "<b>"

--- a/xpath-injection/src/main/java/org/owasp/webgoat/plugin/XPATHInjection.java
+++ b/xpath-injection/src/main/java/org/owasp/webgoat/plugin/XPATHInjection.java
@@ -134,7 +134,7 @@ public class XPATHInjection extends LessonAdapter
                 return ec;
             }
 
-            String dir = LessonUtil.getLessonDirectory(s, this) + "/xml/" + "/EmployeesData.xml";
+            String dir = LessonUtil.getLessonDirectory(s, this) + "/xml/" + "EmployeesData.xml";
             File d = new File(dir);
             XPathFactory factory = XPathFactory.newInstance();
             XPath xPath = factory.newXPath();


### PR DESCRIPTION
Fix the above issue - Lesson Ajax Security "LAB: Client Side Filtering"
- can't validate stage 2 (#231). Forward slash was not being applied to
the above function. Added forward slash so the page will not return a
404.